### PR TITLE
Fix a issue when Javadoc generation

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/s3/sink/internal/utils/AclDeserializer.java
+++ b/component/src/main/java/io/siddhi/extension/io/s3/sink/internal/utils/AclDeserializer.java
@@ -32,7 +32,7 @@ import java.util.List;
  * {@code ACLDeserializer} de-serializes bucket ACL from ACL definition and generate list of {@code Grant}s.
  * The accepted ACL definition is as follows.
  * <p>
- * Ex: 'canonical:<USER_UUID>:FullControl,group:LoDelivery:Read,email:john@doe.com:Write,email:jane@doe.com:Read'
+ * Ex: 'canonical:USER_UUID:FullControl,group:LoDelivery:Read,email:john@doe.com:Write,email:jane@doe.com:Read'
  */
 public class AclDeserializer {
 


### PR DESCRIPTION
## Purpose
This PR fixes an error while generating Javadocs.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes