### PR TITLE
Fix NPE when bucket.acl is not provided

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/s3/sink/internal/ServiceClient.java
+++ b/component/src/main/java/io/siddhi/extension/io/s3/sink/internal/ServiceClient.java
@@ -148,7 +148,11 @@ public class ServiceClient {
     }
 
     private AccessControlList buildBucketACL() {
-        List<Grant> grants = AclDeserializer.deserialize(config.getBucketAcl());
+        String bucketAcl = config.getBucketAcl();
+        if (bucketAcl == null || bucketAcl.isEmpty()) {
+            return null;
+        }
+        List<Grant> grants = AclDeserializer.deserialize(bucketAcl);
         if (grants.size() > 0) {
             AccessControlList acl = new AccessControlList();
             acl.grantAllPermissions(grants.toArray(new Grant[0]));


### PR DESCRIPTION
## Purpose
This PR fixes an NPE when the bucket.acl not provided for a non-existent bucket.

Resolves: https://github.com/siddhi-io/siddhi-io-s3/issues/7

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes